### PR TITLE
feat: add custom background image support

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,6 +37,65 @@ Values: `system`, `light`, `dark`, `deep`, `sepia`, `bluer`
 
 Default: `system`
 
+## Background
+
+You can customize background: 
+
+### Image
+
+Specify a background image from the `data/backgrounds` directory:
+
+```yaml
+background:
+  image: my-background.jpg
+```
+
+Supported formats: `jpg`, `jpeg`, `png`, `gif`, `webp`, `svg`
+
+### URL
+
+Alternatively, you can use an external image URL:
+
+```yaml
+background:
+  url: https://example.com/background.jpg
+```
+
+### Opacity
+
+Control the background image opacity:
+
+```yaml
+background:
+  opacity: 0.5
+```
+
+Values: `0.0 - 1.0` (where `0` is fully transparent and `1` is fully opaque)
+
+Default: `1.0`
+
+### Blur
+
+Apply a blur effect to the background image:
+
+```yaml
+background:
+  blur: 5
+```
+
+Values: `0` and higher (in pixels)
+
+Default: `0`
+
+### Complete example
+
+```yaml
+background:
+  image: wallpaper.jpg
+  opacity: 0.8
+  blur: 3
+```
+
 ## Check updates
 
 This option is responsible for automatically checking for updates.

--- a/src/components/Background.vue
+++ b/src/components/Background.vue
@@ -1,0 +1,47 @@
+<template>
+  <div 
+    v-if="backgroundUrl" 
+    class="fixed inset-0 -z-10"
+    :style="backgroundStyle"
+  />
+</template>
+
+<script setup lang="ts">
+const { $settings } = useNuxtApp()
+
+const backgroundUrl = computed(() => {
+  const bg = $settings.background
+  
+  if (!bg) return null
+
+  if (bg.url) {
+    return bg.url
+  }
+
+  if (bg.image) {
+    return `/api/background/${bg.image}`
+  }
+
+  return null
+})
+
+const backgroundStyle = computed(() => {
+  const bg = $settings.background
+  
+  if (!backgroundUrl.value) {
+    return {}
+  }
+
+  const opacity = bg?.opacity !== undefined ? bg.opacity : 1
+  const blur = bg?.blur !== undefined ? bg.blur : 0
+
+  return {
+    backgroundImage: `url('${backgroundUrl.value}')`,
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    backgroundRepeat: 'no-repeat',
+    opacity: opacity.toString(),
+    filter: blur > 0 ? `blur(${blur}px)` : 'none',
+  }
+})
+</script>

--- a/src/layouts/default.vue
+++ b/src/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="min-h-screen">
+    <Background />
     <div class="max-w-screen-2xl mx-auto xl:flex-row px-4">
       <slot />
     </div>

--- a/src/server/api/background/[filename].ts
+++ b/src/server/api/background/[filename].ts
@@ -1,0 +1,88 @@
+import { stat, createReadStream } from 'node:fs'
+import { promisify } from 'node:util'
+import { join, normalize, basename } from 'node:path'
+import { createHash } from 'node:crypto'
+
+const statAsync = promisify(stat)
+
+const mimeTypes: Record<string, string> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  svg: 'image/svg+xml'
+}
+
+const ALLOWED_EXTENSIONS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'svg'])
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+
+export default defineEventHandler(async (event) => {
+  const filename = getRouterParam(event, 'filename')
+  
+  if (!filename) {
+    throw createError({
+      statusCode: 400,
+      message: 'Filename is required'
+    })
+  }
+
+  const safeName = basename(filename)
+  if (safeName !== filename || filename.includes('..') || filename.includes('/') || filename.includes('\\')) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid filename'
+    })
+  }
+
+  const ext = safeName.split('.').pop()?.toLowerCase()
+  if (!ext || !ALLOWED_EXTENSIONS.has(ext)) {
+    throw createError({
+      statusCode: 400,
+      message: 'Invalid file type'
+    })
+  }
+
+  const backgroundsDir = join(process.cwd(), 'data', 'backgrounds')
+  const filePath = normalize(join(backgroundsDir, safeName))
+
+  if (!filePath.startsWith(backgroundsDir)) {
+    throw createError({
+      statusCode: 403,
+      message: 'Access denied'
+    })
+  }
+
+  let fileStats
+  try {
+    fileStats = await statAsync(filePath)
+  } catch {
+    throw createError({
+      statusCode: 404,
+      message: 'Background image not found'
+    })
+  }
+
+  if (fileStats.size > MAX_FILE_SIZE) {
+    throw createError({
+      statusCode: 413,
+      message: 'File too large'
+    })
+  }
+
+  const etag = `"${createHash('md5').update(`${filePath}-${fileStats.mtime.getTime()}-${fileStats.size}`).digest('hex')}"`
+  
+  const ifNoneMatch = getRequestHeader(event, 'if-none-match')
+  if (ifNoneMatch === etag) {
+    setResponseStatus(event, 304)
+    return null
+  }
+
+  setResponseHeader(event, 'Content-Type', mimeTypes[ext])
+  setResponseHeader(event, 'ETag', etag)
+  setResponseHeader(event, 'Cache-Control', 'public, max-age=31536000, immutable')
+  setResponseHeader(event, 'Last-Modified', fileStats.mtime.toUTCString())
+  setResponseHeader(event, 'Content-Length', fileStats.size.toString())
+
+  return sendStream(event, createReadStream(filePath))
+})

--- a/src/server/utils/config.ts
+++ b/src/server/utils/config.ts
@@ -35,6 +35,10 @@ export function getDefaultConfig(): CompleteConfig {
     title: 'Mafl Home Page',
     lang: 'en',
     theme: 'system',
+    background: {
+      opacity: 1,
+      blur: 0,
+    },
     checkUpdates: true,
     layout: {
       grid: {

--- a/src/server/validations/config.ts
+++ b/src/server/validations/config.ts
@@ -1,10 +1,18 @@
 import { z } from 'zod'
 import { serviceSchema, tagSchema } from './service'
 
+export const backgroundSchema = z.object({
+  image: z.string().optional(),
+  url: z.string().url().optional(),
+  opacity: z.number().min(0).max(1).optional(),
+  blur: z.number().min(0).optional(),
+}).optional()
+
 export const configSchema = z.object({
   title: z.string().optional(),
   lang: z.string().optional(),
   theme: z.string().optional(),
+  background: backgroundSchema,
   checkUpdates: z.boolean().optional(),
   tags: z.array(tagSchema).optional(),
   services: z.union([

--- a/src/types/config.d.ts
+++ b/src/types/config.d.ts
@@ -14,6 +14,13 @@ export interface Behaviour {
   target?: '_blank' | '_self' | '_parent' | '_top'
 }
 
+export interface Background {
+  image?: string
+  url?: string
+  opacity?: number
+  blur?: number
+}
+
 export interface Layout {
   grid: {
     small: number
@@ -27,6 +34,7 @@ export interface Config {
   title?: string
   lang?: 'en' | 'ru' | 'zh' | 'hi' | 'es' | 'ar' | 'pl' | 'fr' | 'de' | 'gr'
   theme?: 'system' | 'light' | 'dark' | 'deep' | 'sepia' | 'bluer'
+  background?: Background
   layout?: Layout
   behaviour?: Behaviour
   tags: Tag[]


### PR DESCRIPTION
- Add background configuration schema with url, image, opacity, and blur options
- Create API endpoint to serve background images from data/backgrounds/
- Update main layout to include background component
- Add validation for background configuration options
- Add documentation for background feature

Closes #176