### PR TITLE
feat: add config export functionality

### DIFF
--- a/src/components/ExportConfig.vue
+++ b/src/components/ExportConfig.vue
@@ -1,0 +1,57 @@
+<template>
+  <div class="fixed bottom-4 right-4 z-50">
+    <button
+      class="bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-lg shadow-lg transition-colors duration-200 flex items-center gap-2"
+      @click="exportConfig"
+      :disabled="isExporting"
+    >
+      <svg
+        v-if="!isExporting"
+        xmlns="http://www.w3.org/2000/svg"
+        class="h-5 w-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+        />
+      </svg>
+      <span v-if="isExporting">Exporting...</span>
+      <span v-else>Export Config</span>
+    </button>
+  </div>
+</template>
+
+<script setup lang="ts">
+const isExporting = ref(false)
+
+async function exportConfig() {
+  isExporting.value = true
+  try {
+    const response = await fetch('/api/config/export')
+    
+    if (!response.ok) {
+      throw new Error('Failed to export config')
+    }
+
+    const blob = await response.blob()
+    const url = window.URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'mafl-config.yml'
+    document.body.appendChild(a)
+    a.click()
+    window.URL.revokeObjectURL(url)
+    document.body.removeChild(a)
+  } catch (error) {
+    console.error('Export failed:', error)
+    alert('Failed to export config. Please try again.')
+  } finally {
+    isExporting.value = false
+  }
+}
+</script>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -5,6 +5,7 @@
     v-bind="{ ...group, grid: $settings.layout.grid }"
   />
   <Update v-if="$settings.checkUpdates" />
+  <ExportConfig />
 </template>
 
 <script setup lang="ts">

--- a/src/server/api/config/export.ts
+++ b/src/server/api/config/export.ts
@@ -1,0 +1,63 @@
+import yaml from 'yaml'
+import type { CompleteConfig } from '~/types'
+
+export default defineEventHandler(async (event) => {
+  const storage = useStorage('main')
+  const config = await storage.getItem<CompleteConfig>('config')
+
+  if (!config) {
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Bad loading config',
+    })
+  }
+
+  // Convert services back to the original YAML format
+  const exportConfig: Record<string, any> = {
+    title: config.title,
+    lang: config.lang,
+    theme: config.theme,
+    background: config.background,
+    checkUpdates: config.checkUpdates,
+    layout: config.layout,
+    behaviour: config.behaviour,
+    tags: config.tags,
+  }
+
+  // Convert services structure
+  if (config.services.length === 1 && !config.services[0].title) {
+    // Simple array format
+    exportConfig.services = config.services[0].items.map(service => {
+      const { id, ...rest } = service
+      return {
+        ...rest,
+        tags: service.tags?.map(tag => typeof tag === 'string' ? tag : tag.name),
+      }
+    })
+  } else {
+    // Grouped format
+    exportConfig.services = config.services.reduce((acc, group) => {
+      const groupName = group.title || 'default'
+      acc[groupName] = group.items.map(service => {
+        const { id, ...rest } = service
+        return {
+          ...rest,
+          tags: service.tags?.map(tag => typeof tag === 'string' ? tag : tag.name),
+        }
+      })
+      return acc
+    }, {} as Record<string, any>)
+  }
+
+  const yamlContent = yaml.stringify(exportConfig, {
+    defaultStringType: 'QUOTE_DOUBLE',
+    defaultKeyType: 'PLAIN',
+  })
+
+  setResponseHeaders(event, {
+    'Content-Type': 'application/x-yaml',
+    'Content-Disposition': 'attachment; filename="mafl-config.yml"',
+  })
+
+  return yamlContent
+})


### PR DESCRIPTION
## Description
Implements config export functionality as requested in #3

## Changes
- ✅ Created  endpoint to export config as YAML
- ✅ Added  component with download button (bottom-right corner)
- ✅ Converts internal config structure back to original YAML format
- ✅ Handles both simple array and grouped service formats
- ✅ Removes internal IDs and normalizes tag references
- ✅ Proper Content-Disposition header for file download

## Testing
The export button appears as a floating action button in the bottom-right corner of the homepage. Clicking it downloads the current configuration as `mafl-config.yml`.

## Acceptance Criteria
- [x] Config can be exported
- [x] Export format is valid YAML
- [x] Documentation updated (in PR description)
- [ ] Tests added (no existing test framework found in repo)

Closes #3